### PR TITLE
Build and push an container image to the repository container registry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,5 @@
 {
   "name": "tidybee-hub codespace",
-  "image": "mcr.microsoft.com/dotnet/sdk:7.0",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
       "version": "7.0",

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,58 @@
+name: Build and push tidybee-hub images to ghcr.io
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push-matrix:
+    strategy:
+      matrix:
+        service: [ApiGateway, Auth, DataProcessing]
+        include:
+            - service_name: api-gateway
+              service: ApiGateway
+            - service_name: auth
+              service: Auth
+            - service_name: data-processing
+              service: DataProcessing
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Fetch metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: tidybee/tidybee-${{ matrix.service}}
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.service }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64v8
+          platforms: linux/amd64
           file: ${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm64v8
+          platforms: linux/arm64/v8
           file: ${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8
           file: ${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-and-push-matrix:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         service: [ApiGateway, Auth, DataProcessing]
         include:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -53,6 +56,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/arm64v8
           file: ${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,6 +12,7 @@ env:
 jobs:
   build-and-push-matrix:
     strategy:
+      fail-fast: true
       matrix:
         service: [ApiGateway, Auth, DataProcessing]
         include:
@@ -39,7 +40,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: tidybee/tidybee-${{ matrix.service}}
+          images: tidybee/tidybee-${{ matrix.service_name }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v3
@@ -51,7 +52,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: ${{ matrix.service }}
+          context: .
+          file: ${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64v8
           file: ${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,7 +40,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: tidybee/tidybee-${{ matrix.service_name }}
+          images: tidybee/tidybee-hub-${{ matrix.service_name }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v3

--- a/ApiGateway/Dockerfile
+++ b/ApiGateway/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG TARGETARCH
 WORKDIR /src
 COPY ApiGateway/ApiGateway.csproj ./
-RUN dotnet restore "./ApiGateway.csproj" -a $TARGETARCH -r linux-arm64
+RUN dotnet restore "./ApiGateway.csproj" -a $TARGETARCH
 COPY ApiGateway/ ./
 RUN dotnet build "ApiGateway.csproj" -c Release -o /app/build -a $TARGETARCH
 

--- a/ApiGateway/Dockerfile
+++ b/ApiGateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM AS base
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 ARG TARGETARCH
 WORKDIR /app
 

--- a/ApiGateway/Dockerfile
+++ b/ApiGateway/Dockerfile
@@ -1,8 +1,5 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG TARGETARCH
-WORKDIR /app
-
-FROM base AS build
 WORKDIR /src
 COPY ApiGateway/ApiGateway.csproj ./
 RUN dotnet restore "./ApiGateway.csproj" -a $TARGETARCH

--- a/ApiGateway/Dockerfile
+++ b/ApiGateway/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM AS base
 ARG TARGETARCH
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM base AS build
 WORKDIR /src
 COPY ApiGateway/ApiGateway.csproj ./
 RUN dotnet restore "./ApiGateway.csproj" -a $TARGETARCH

--- a/ApiGateway/Dockerfile
+++ b/ApiGateway/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG TARGETARCH
 WORKDIR /src
 COPY ApiGateway/ApiGateway.csproj ./
-RUN dotnet restore "./ApiGateway.csproj" -a $TARGETARCH
+RUN dotnet restore "./ApiGateway.csproj" -a $TARGETARCH -r linux-arm64
 COPY ApiGateway/ ./
 RUN dotnet build "ApiGateway.csproj" -c Release -o /app/build -a $TARGETARCH
 

--- a/ApiGateway/Dockerfile
+++ b/ApiGateway/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet build "ApiGateway.csproj" -c Release -o /app/build -a $TARGETARCH
 FROM build AS publish
 RUN dotnet publish "ApiGateway.csproj" -c Release -o /app/publish -a $TARGETARCH
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS final
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS final
 LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-hub
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/ApiGateway/Dockerfile
+++ b/ApiGateway/Dockerfile
@@ -12,6 +12,7 @@ FROM build AS publish
 RUN dotnet publish "ApiGateway.csproj" -c Release -o /app/publish
 
 FROM base AS final
+LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-hub
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_ENVIRONMENT=Container

--- a/ApiGateway/Dockerfile
+++ b/ApiGateway/Dockerfile
@@ -1,19 +1,21 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM --platform=$BUILDPLATFORM AS base
+ARG TARGETARCH
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ApiGateway/ApiGateway.csproj ./
-RUN dotnet restore "./ApiGateway.csproj"
+RUN dotnet restore "./ApiGateway.csproj" -a $TARGETARCH
 COPY ApiGateway/ ./
-RUN dotnet build "ApiGateway.csproj" -c Release -o /app/build
+RUN dotnet build "ApiGateway.csproj" -c Release -o /app/build -a $TARGETARCH
 
 FROM build AS publish
-RUN dotnet publish "ApiGateway.csproj" -c Release -o /app/publish
+RUN dotnet publish "ApiGateway.csproj" -c Release -o /app/publish -a $TARGETARCH
 
-FROM base AS final
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS final
 LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-hub
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_ENVIRONMENT=Container
+USER $APP_UID
 ENTRYPOINT ["dotnet", "ApiGateway.dll"]

--- a/Auth/Dockerfile
+++ b/Auth/Dockerfile
@@ -1,17 +1,18 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+ARG TARGETARCH
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY Auth/Auth.csproj ./
-RUN dotnet restore "./Auth.csproj"
+RUN dotnet restore "./Auth.csproj" -a $TARGETARCH
 COPY Auth/ ./
-RUN dotnet build "Auth.csproj" -c Release -o /app/build
+RUN dotnet build "Auth.csproj" -c Release -o /app/build -a $TARGETARCH
 
 FROM build AS publish
-RUN dotnet publish "Auth.csproj" -c Release -o /app/publish
+RUN dotnet publish "Auth.csproj" -c Release -o /app/publish -a $TARGETARCH
 
-FROM base AS final
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS final
 LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-hub
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/Auth/Dockerfile
+++ b/Auth/Dockerfile
@@ -12,6 +12,7 @@ FROM build AS publish
 RUN dotnet publish "Auth.csproj" -c Release -o /app/publish
 
 FROM base AS final
+LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-hub
 WORKDIR /app
 COPY --from=publish /app/publish .
 COPY Auth/Database /app/Database

--- a/Auth/Dockerfile
+++ b/Auth/Dockerfile
@@ -1,8 +1,5 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG TARGETARCH
-WORKDIR /app
-
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY Auth/Auth.csproj ./
 RUN dotnet restore "./Auth.csproj" -a $TARGETARCH

--- a/DataProcessing/Dockerfile
+++ b/DataProcessing/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+ARG TARGETARCH
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
@@ -6,12 +7,12 @@ WORKDIR /src
 COPY DataProcessing/DataProcessing.csproj ./
 RUN dotnet restore "./DataProcessing.csproj"
 COPY DataProcessing/ ./
-RUN dotnet build "DataProcessing.csproj" -c Release -o /app/build
+RUN dotnet build "DataProcessing.csproj" -c Release -o /app/build -a $TARGETARCH
 
 FROM build AS publish
-RUN dotnet publish "DataProcessing.csproj" -c Release -o /app/publish
+RUN dotnet publish "DataProcessing.csproj" -c Release -o /app/publish -a $TARGETARCH
 
-FROM base AS final
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS final
 LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-hub
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/DataProcessing/Dockerfile
+++ b/DataProcessing/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG TARGETARCH
 WORKDIR /src
 COPY DataProcessing/DataProcessing.csproj ./

--- a/DataProcessing/Dockerfile
+++ b/DataProcessing/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS build
 ARG TARGETARCH
 WORKDIR /src
 COPY DataProcessing/DataProcessing.csproj ./
@@ -6,7 +6,7 @@ RUN dotnet restore "./DataProcessing.csproj" -a $TARGETARCH
 COPY DataProcessing/ ./
 RUN dotnet build "DataProcessing.csproj" -c Release -o /app/build -a $TARGETARCH
 
-FROM build AS publish
+FROM build  AS publish
 RUN dotnet publish "DataProcessing.csproj" -c Release -o /app/publish -a $TARGETARCH
 
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS final

--- a/DataProcessing/Dockerfile
+++ b/DataProcessing/Dockerfile
@@ -1,11 +1,8 @@
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 ARG TARGETARCH
-WORKDIR /app
-
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY DataProcessing/DataProcessing.csproj ./
-RUN dotnet restore "./DataProcessing.csproj"
+RUN dotnet restore "./DataProcessing.csproj" -a $TARGETARCH
 COPY DataProcessing/ ./
 RUN dotnet build "DataProcessing.csproj" -c Release -o /app/build -a $TARGETARCH
 

--- a/DataProcessing/Dockerfile
+++ b/DataProcessing/Dockerfile
@@ -12,6 +12,7 @@ FROM build AS publish
 RUN dotnet publish "DataProcessing.csproj" -c Release -o /app/publish
 
 FROM base AS final
+LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-hub
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_ENVIRONMENT=Development


### PR DESCRIPTION
Adds the `tidybee-hub-api-gateway`, `tidybee-hub-auth`, and, `tidybee-hub-dataprocesing` docker images to the repository for a better deployment.
Actions logs example can be found here: https://github.com/TidyBee/tidybee-hub-deployment/actions/runs/8360737737

The generated container images can be found [here](https://github.com/orgs/TidyBee/packages?repo_name=tidybee-hub-deployment) (see screen):
![image](https://github.com/TidyBee/tidybee-hub/assets/38893947/f51433b4-5689-482b-8268-0833ffd85456)
