### PR TITLE
Add FolderEvent to protobuf definition and implementation in tidyevent service

### DIFF
--- a/TidyEvents/Protos/tidybee_events.proto
+++ b/TidyEvents/Protos/tidybee_events.proto
@@ -44,10 +44,11 @@ message FolderEventRequest {
     // Type of the event
     FileEventType event_type = 1;
     // Path relative to the watched directory
-    string pretty_path = 2;
+    string old_path = 2;
     // Full canonical path
-    repeated string path = 3;
+    optional string new_path = 3;
 }
+
 
 // Data sent by the agent when connecting to the hub
 message AgentData {

--- a/TidyEvents/Protos/tidybee_events.proto
+++ b/TidyEvents/Protos/tidybee_events.proto
@@ -39,6 +39,15 @@ message FileEventRequest {
     optional google.protobuf.Timestamp last_accessed = 7;
 }
 
+// Separate event for folder events needed by the Hub when a Delete or Modify event occurs on a folder so that childs can be removed
+message FolderEventRequest {
+    // Type of the event
+    FileEventType event_type = 1;
+    // Path relative to the watched directory
+    string pretty_path = 2;
+    // Full canonical path
+    repeated string path = 3;
+}
 
 // Data sent by the agent when connecting to the hub
 message AgentData {
@@ -62,4 +71,5 @@ message FileInfoEventResponse {
 
 service TidyBeeEvents {
     rpc FileEvent(stream FileEventRequest) returns (FileInfoEventResponse);
+    rpc FolderEvent(stream FolderEventRequest) returns (FileInfoEventResponse);
 }


### PR DESCRIPTION
### New Folder Event Type

Change to tidyevent protobuf is needed to allow the Hub to:
- remove child items from a deleted directory
- change child paths and pretty paths from a moved directory (within the watcher scope)
