### PR TITLE
Sync cloud services directly from an HTTP request rather than a gRPC call

### DIFF
--- a/Auth/Auth.csproj
+++ b/Auth/Auth.csproj
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Protobuf Include="Protos\notion.proto" GrpcServices="Client" />
+    <Protobuf Include="Protos\google_drive.proto" GrpcServices="Client" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
 	  <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.7" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">

--- a/Auth/Controllers/CloudController.cs
+++ b/Auth/Controllers/CloudController.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Mvc;
+using TidyEventsGDrive.Grpc;
+using TidyEventsNotion.Grpc;
+using Auth.Models;
+
+namespace auth.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class CloudController : ControllerBase
+{
+    private readonly GoogleDriveGrpcSync.GoogleDriveGrpcSyncClient _googleDriveGrpcSyncClient;
+    private readonly NotionSync.NotionSyncClient _notionGrpcSyncClient;
+
+    public CloudController(GoogleDriveGrpcSync.GoogleDriveGrpcSyncClient googleDriveGrpcSyncClient, NotionSync.NotionSyncClient notionGrpcSyncClient)
+    {
+        _googleDriveGrpcSyncClient = googleDriveGrpcSyncClient;
+        _notionGrpcSyncClient = notionGrpcSyncClient;
+    }
+
+    [HttpPost("SyncGoogle")]
+    public async Task<IActionResult> SyncGoogle([FromBody] GoogleDriveSyncRequestModel googleDriveSyncRequestModel)
+    {
+        if (googleDriveSyncRequestModel.Oauth2Token == null)
+        {
+            return BadRequest("Oauth2Token is required");
+        }
+
+        var sync_request = await _googleDriveGrpcSyncClient.SyncFilesAsync(new SyncFilesRequest
+        {
+            Oauth2Token = googleDriveSyncRequestModel.Oauth2Token
+        });
+
+        if (!sync_request.Success)
+        {
+            return BadRequest($"Google Drive files sync failed with error: {sync_request.Message}");
+        }
+        
+        return Ok("Google Drive files synced successfully");
+    }
+
+    [HttpPost("SyncNotion")]
+    public async Task<IActionResult> SyncNotion([FromBody] NotionSyncResponseModel notionSyncResponseModel)
+    {
+        if (notionSyncResponseModel.DatabaseId == null)
+        {
+            return BadRequest("DatabaseId is required");
+        }
+
+        var sync_request = await _notionGrpcSyncClient.SyncDatabaseAsync(new SyncDatabaseRequest
+        {
+            DatabaseId = notionSyncResponseModel.DatabaseId
+        });
+
+        if (!sync_request.Success)
+        {
+            return BadRequest($"Notion database sync failed with error: {sync_request.Message}");
+        }
+
+        return Ok("Notion database synced successfully");
+    }
+}

--- a/Auth/Models/CloudServiceSyncRequestModel.cs
+++ b/Auth/Models/CloudServiceSyncRequestModel.cs
@@ -1,0 +1,12 @@
+namespace Auth.Models
+{
+    public class GoogleDriveSyncRequestModel
+    {
+        public string? Oauth2Token { get; set; }
+    }
+
+    public class NotionSyncResponseModel
+    {
+        public string? DatabaseId { get; set; }
+    }
+}

--- a/Auth/Protos/google_drive.proto
+++ b/Auth/Protos/google_drive.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+option csharp_namespace = "TidyEventsGDrive.Grpc";
+
+service GoogleDriveGrpcSync {
+    // Define the RPC for syncing Google Drive files
+    rpc SyncFiles(SyncFilesRequest) returns (SyncFilesResponse);
+}
+
+// Define the request message for syncing Google Drive files
+message SyncFilesRequest {
+    string oauth2Token = 1; // The OAuth2 token for authentication
+}
+
+// Define the response message for syncing Google Drive files
+message SyncFilesResponse {
+    bool success = 1;
+    string message = 2;
+}

--- a/Auth/Protos/notion.proto
+++ b/Auth/Protos/notion.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+option csharp_namespace = "TidyEventsNotion.Grpc";
+
+service NotionSync {
+    // Define the RPC for syncing a Notion database
+    rpc SyncDatabase(SyncDatabaseRequest) returns (SyncDatabaseResponse);
+}
+
+// Define the request message for syncing Notion
+message SyncDatabaseRequest {
+    string databaseId = 1;
+}
+
+// Define the response message for syncing Notion
+message SyncDatabaseResponse {
+    bool success = 1;
+    string message = 2;
+}

--- a/Auth/appsettings.Container.json
+++ b/Auth/appsettings.Container.json
@@ -12,6 +12,10 @@
       }
     }
   },
+  "TidyEvents": {
+    "Address": "hub-tidy-events",
+    "Port": 5057
+  },
   "AllowedHosts": "*",
   "ConnectionStrings": {
       "DatabaseConnection": "Data Source=./Database/HubDatabase.db"

--- a/Auth/appsettings.json
+++ b/Auth/appsettings.json
@@ -16,6 +16,10 @@
   "ConnectionStrings": {
       "DatabaseConnection": "Data Source=./Database/HubDatabase.db"
   },
+  "TidyEvents": {
+    "Address": "localhost",
+    "Port": 5057
+  },
   "EnableAutoMigration": true,
   "StatusHandlerFrequency": 10,
   "InactiveAgentThresholds": {


### PR DESCRIPTION
This pull request is the first step towards migrating cloud services synchronization from sync by calling a gRPC service in TidyEvents from the frontend to calling an HTTP Rest endpoint. 

This is a crucial step to integrate HTTPS everywhere.